### PR TITLE
[-] Correção para assinar xml quando o mesmo não tem tag de controle.

### DIFF
--- a/src/ACBr.Net.DFe.Core.Tests/ACBr.Net.DFe.Core.Tests.csproj
+++ b/src/ACBr.Net.DFe.Core.Tests/ACBr.Net.DFe.Core.Tests.csproj
@@ -85,7 +85,7 @@
       <Version>1.2.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>5.0.1</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.3</Version>

--- a/src/ACBr.Net.DFe.Core/ACBr.Net.DFe.Core.csproj
+++ b/src/ACBr.Net.DFe.Core/ACBr.Net.DFe.Core.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyVersion>1.2.8.0</AssemblyVersion>
     <FileVersion>1.2.8.0</FileVersion>
-    <Version>1.2.8.1</Version>
+    <Version>1.2.8.2</Version>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
@@ -65,7 +65,7 @@
     <PackageReference Include="ExtraConstraints.Fody" Version="1.14.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Fody" Version="6.5.0">
+    <PackageReference Include="Fody" Version="6.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -78,7 +78,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
[-] Correção para assinar xml quando o atributo da assinatura é diferente de Id.